### PR TITLE
feat: make validation optional, update timestamp property

### DIFF
--- a/src/package/database/model.ts
+++ b/src/package/database/model.ts
@@ -312,9 +312,11 @@ export abstract class Model {
 		const constructor = this.constructor as typeof Model;
 
 		// Run validation
-		const validation = constructor.validation.create.safeParse(insertData);
-		if (!validation.success) {
-			throw new Error(`Validation failed: ${validation.error.message}`);
+		if(constructor.validation) {
+			const validation = constructor.validation.create.safeParse(insertData);
+			if (!validation.success) {
+				throw new Error(`Validation failed: ${validation.error.message}`);
+			}
 		}
 
 		// Run creating hooks
@@ -356,9 +358,11 @@ export abstract class Model {
 		}
 
 		// Run validation
-		const validation = constructor.validation.update.safeParse(updateData);
-		if (!validation.success) {
-			throw new Error(`Validation failed: ${validation.error.message}`);
+		if(constructor.validation) {
+			const validation = constructor.validation.update.safeParse(updateData);
+			if (!validation.success) {
+				throw new Error(`Validation failed: ${validation.error.message}`);
+			}
 		}
 
 		// Run updating hooks
@@ -477,7 +481,7 @@ export interface ModelConfig {
 	primaryKey?: string;
 	fillable?: string[];
 	hidden?: string[];
-	validation: {
+	validation?: {
 		create: z.ZodSchema;
 		update: z.ZodSchema;
 	};
@@ -496,11 +500,11 @@ export function createModel(name: string, config: ModelConfig): typeof Model {
 		static primaryKey = config.primaryKey || 'id';
 		static fillable = config.fillable || []
 		static hidden = config.hidden || []
-		static validation = {
+		static validation = config.validation ? {
 			create: config.validation.create,
 			update: config.validation.update
-		};
-		static timestamps = true;
+		} : null;
+		static timestamps = config.timestamps !== false; // Default to true unless explicitly set to false
 		static hooks = config.hooks || {};
 		static realtime = config.realtime || {};
 		static relationships = config.relationships || {};


### PR DESCRIPTION
This pull request introduces changes to the `Model` class in `src/package/database/model.ts` to make validation optional and improve configurability. The most important updates include adding checks for the presence of validation schemas, modifying the `ModelConfig` interface to allow optional validation, and ensuring default behaviors for timestamps.

### Updates to validation handling:

* [`src/package/database/model.ts`](diffhunk://#diff-2ebbf1592489a36776c9fb49049b3f99d6a55f2dc21e856bc179f786e3cfd53eR315-R320): Added checks in the `Model` class for the presence of validation schemas before running validation during `create` and `update` operations. This prevents errors when validation is not configured. [[1]](diffhunk://#diff-2ebbf1592489a36776c9fb49049b3f99d6a55f2dc21e856bc179f786e3cfd53eR315-R320) [[2]](diffhunk://#diff-2ebbf1592489a36776c9fb49049b3f99d6a55f2dc21e856bc179f786e3cfd53eR361-R366)
* [`src/package/database/model.ts`](diffhunk://#diff-2ebbf1592489a36776c9fb49049b3f99d6a55f2dc21e856bc179f786e3cfd53eL480-R484): Modified the `ModelConfig` interface to make the `validation` property optional, allowing models to be created without validation schemas.

### Improvements to default configurations:

* [`src/package/database/model.ts`](diffhunk://#diff-2ebbf1592489a36776c9fb49049b3f99d6a55f2dc21e856bc179f786e3cfd53eL499-R507): Updated the `createModel` function to set `timestamps` to `true` by default unless explicitly configured otherwise, and adjusted the `validation` assignment to handle cases where no validation is provided.